### PR TITLE
Ajout de la documentation automatique

### DIFF
--- a/docs/sources/classes.elements.rst
+++ b/docs/sources/classes.elements.rst
@@ -1,0 +1,21 @@
+classes.elements package
+========================
+
+Submodules
+----------
+
+classes.elements.budget module
+------------------------------
+
+.. automodule:: classes.elements.budget
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: classes.elements
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/sources/classes.rst
+++ b/docs/sources/classes.rst
@@ -1,0 +1,19 @@
+classes package
+===============
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   classes.elements
+   classes.sql
+
+Module contents
+---------------
+
+.. automodule:: classes
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/sources/classes.sql.rst
+++ b/docs/sources/classes.sql.rst
@@ -1,0 +1,29 @@
+classes.sql package
+===================
+
+Submodules
+----------
+
+classes.sql.base module
+-----------------------
+
+.. automodule:: classes.sql.base
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+classes.sql.budget module
+-------------------------
+
+.. automodule:: classes.sql.budget
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: classes.sql
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/sources/conf.py
+++ b/docs/sources/conf.py
@@ -1,0 +1,59 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../..'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'Comptes'
+copyright = '2022, Panda <panda@delmasweb.net>'
+author = 'Panda <panda@delmasweb.net>'
+
+# The full version, including alpha/beta/rc tags
+release = '1.0'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.autosummary"
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/sources/index.rst
+++ b/docs/sources/index.rst
@@ -1,0 +1,22 @@
+.. Comptes documentation master file, created by
+   sphinx-quickstart on Sun Feb  6 18:07:45 2022.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to Python Weather App's documentation!
+==============================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   modules
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/sources/main.rst
+++ b/docs/sources/main.rst
@@ -1,0 +1,7 @@
+main module
+===========
+
+.. automodule:: main
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/sources/make.bat
+++ b/docs/sources/make.bat
@@ -1,1 +1,2 @@
+sphinx-apidoc.exe -f -o . ..\.. 
 sphinx-build.exe -a -b html . ..\build

--- a/docs/sources/make.bat
+++ b/docs/sources/make.bat
@@ -1,0 +1,1 @@
+sphinx-build.exe -a -b html . ..\build

--- a/docs/sources/modules.rst
+++ b/docs/sources/modules.rst
@@ -1,0 +1,10 @@
+Comptes
+=======
+
+.. toctree::
+   :maxdepth: 4
+
+   classes
+   main
+   tests
+   views

--- a/docs/sources/tests.integration.rst
+++ b/docs/sources/tests.integration.rst
@@ -1,0 +1,21 @@
+tests.integration package
+=========================
+
+Submodules
+----------
+
+tests.integration.budget module
+-------------------------------
+
+.. automodule:: tests.integration.budget
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: tests.integration
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/sources/tests.rst
+++ b/docs/sources/tests.rst
@@ -1,0 +1,19 @@
+tests package
+=============
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   tests.integration
+   tests.unitaires
+
+Module contents
+---------------
+
+.. automodule:: tests
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/sources/tests.unitaires.classes.elements.rst
+++ b/docs/sources/tests.unitaires.classes.elements.rst
@@ -1,0 +1,21 @@
+tests.unitaires.classes.elements package
+========================================
+
+Submodules
+----------
+
+tests.unitaires.classes.elements.budget\_test module
+----------------------------------------------------
+
+.. automodule:: tests.unitaires.classes.elements.budget_test
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: tests.unitaires.classes.elements
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/sources/tests.unitaires.classes.rst
+++ b/docs/sources/tests.unitaires.classes.rst
@@ -1,0 +1,18 @@
+tests.unitaires.classes package
+===============================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   tests.unitaires.classes.elements
+
+Module contents
+---------------
+
+.. automodule:: tests.unitaires.classes
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/sources/tests.unitaires.rst
+++ b/docs/sources/tests.unitaires.rst
@@ -1,0 +1,18 @@
+tests.unitaires package
+=======================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   tests.unitaires.classes
+
+Module contents
+---------------
+
+.. automodule:: tests.unitaires
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/sources/views.rst
+++ b/docs/sources/views.rst
@@ -1,0 +1,10 @@
+views package
+=============
+
+Module contents
+---------------
+
+.. automodule:: views
+   :members:
+   :undoc-members:
+   :show-inheritance:


### PR DESCRIPTION
- Ajoute la génération de la documentation en automatique


Pour utiliser la génération automatique de la documentation il est nécessaire de se déplacer dans le dossier docs/source et de lancer le fichier make.bat

`cd docs/source`
`.\make.bat`